### PR TITLE
Fix broken install and update to OpenCV 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=2.4.6
 natsort>=8.4.0
-opencv_python_headless>=4.13.0.92
+opencv-contrib-python-headless>=5.0.0.93
 scikit-image>=0.26.0
 ray>=2.55.1
 numba>=0.65.1

--- a/sundic/sundic.py
+++ b/sundic/sundic.py
@@ -1400,7 +1400,7 @@ def _akazeDetect_(adPoints, adActive, F, G):
         F, None, 0, 255, cv.NORM_MINMAX).astype('uint8')
 
     # Setup the akaze detector
-    akaze = cv.AKAZE_create()
+    akaze = cv.xfeatures2d.AKAZE_create()
 
     # Subset data to work with
     X = adPoints[:, :, CompID.XCoordID]


### PR DESCRIPTION
The opencv_python_headless>=4.13.0.92 dependency installs opencv-python-headless 5.0.0.93, which removed the AKAZE_create() function and breaks new SUN-DIC installations.

The dependency is replaced with opencv-contrib-python-headless>=5.0.0.93 and the function is called from the cv2.xfeatures2d namespace.